### PR TITLE
Fix for missing base url in path

### DIFF
--- a/lib/construct-payload.js
+++ b/lib/construct-payload.js
@@ -16,7 +16,7 @@ module.exports = (req, res, group, options = {}, { startedDateTime }) => ({
             ? url.format({
                 protocol: req.protocol,
                 host: req.get('host'),
-                pathname: req.route.path,
+                pathname: `${req.baseUrl}${req.route.path}`,
               })
             : '',
           startedDateTime: startedDateTime.toISOString(),

--- a/lib/process-request.js
+++ b/lib/process-request.js
@@ -18,7 +18,7 @@ module.exports = (req, options = {}) => {
     url: url.format({
       protocol: req.protocol,
       host: req.headers['x-forwarded-host'] || req.get('host'),
-      pathname: req.path,
+      pathname: `${req.baseUrl}${req.path}`,
       query: req.query,
     }),
     httpVersion: req.httpVersion,

--- a/lib/process-response.js
+++ b/lib/process-response.js
@@ -29,7 +29,7 @@ module.exports = (res, options = {}) => {
     headers: objectToArray(res.getHeaders()),
     content: {
       text: JSON.stringify(body),
-      size: res.get('content-length'),
+      size: res.get('content-length') || 0,
       mimeType: res.get('content-type'),
     },
   };

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -9,6 +9,13 @@ const processRequest = require('../lib/process-request');
 function createApp(options) {
   const app = express();
   app.use(bodyParser.json());
+
+  const router = express.Router();
+
+  router.get('/a', (req, res) => res.json(processRequest(req, options)));
+
+  app.use('/test-base-path', router);
+
   app.post('/*', (req, res) => {
     res.json(processRequest(req, options));
   });
@@ -55,6 +62,15 @@ describe('processRequest()', () => {
       .query({ a: 'b' })
       // This regex is for supertest's random port numbers
       .expect(({ body }) => assert(body.url.match(/http:\/\/127.0.0.1:\d+\/path\?a=b/))));
+
+  it('#url-basepath', () =>
+    request(createApp())
+      .post('/test-base-path/a')
+      .query({ a: 'b' })
+      // This regex is for supertest's random port numbers
+      .expect(({ body }) =>
+        assert(body.url.match(/http:\/\/127.0.0.1:\d+\/test-base-path\/a\?a=b/)),
+      ));
 
   it('#url with x-forwarded-host', () =>
     request(createApp())

--- a/test/process-request.test.js
+++ b/test/process-request.test.js
@@ -12,7 +12,7 @@ function createApp(options) {
 
   const router = express.Router();
 
-  router.get('/a', (req, res) => res.json(processRequest(req, options)));
+  router.post('/a', (req, res) => res.json(processRequest(req, options)));
 
   app.use('/test-base-path', router);
 


### PR DESCRIPTION
Seems like in express to get the full path you need to combine `req.baseUrl` and `req.path` or `req.route.path`.

For example `http://dash.readme.io/api/v1/docs/introduction`:

`req.baseUrl = /api/v1/docs`
`req.route.path = /:slug`