### PR TITLE
This allows plain text body responses

### DIFF
--- a/lib/process-response.js
+++ b/lib/process-response.js
@@ -11,16 +11,18 @@ module.exports = (res, options = {}) => {
   let body;
   try {
     body = JSON.parse(res._body); // eslint-disable-line no-underscore-dangle
+
+    // Only apply blacklist/whitelist if it's an object
+    if (options.blacklist) {
+      body = removeProperties(body, options.blacklist);
+    }
+
+    if (options.whitelist) {
+      body = removeOtherProperties(body, options.whitelist);
+    }
   } catch (e) {
-    // Non JSON body, don't attempt to send it off
-  }
-
-  if (options.blacklist && body) {
-    body = removeProperties(body, options.blacklist);
-  }
-
-  if (options.whitelist && body) {
-    body = removeOtherProperties(body, options.whitelist);
+    // Non JSON body
+    body = res._body; // eslint-disable-line no-underscore-dangle
   }
 
   return {

--- a/test/process-response.test.js
+++ b/test/process-response.test.js
@@ -14,7 +14,7 @@ function testResponse(assertion, response) {
 
     // This is done in the main middleware by
     // overwriting res.write/end
-    res._body = JSON.stringify(response); // eslint-disable-line no-underscore-dangle
+    res._body = response; // eslint-disable-line no-underscore-dangle
 
     res.json(response);
   });
@@ -36,7 +36,7 @@ describe('processResponse()', () => {
           );
           return done();
         },
-        { password: '123456', apiKey: 'abcdef', another: 'Hello world' },
+        JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }),
       );
     });
 
@@ -49,7 +49,21 @@ describe('processResponse()', () => {
           );
           return done();
         },
-        { password: '123456', apiKey: 'abcdef', another: 'Hello world' },
+        JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }),
+      );
+    });
+
+    it('should not be applied for plain text bodies', done => {
+      const body = 'hello world: dasdsas';
+      testResponse(
+        res => {
+          assert.deepEqual(
+            processResponse(res, { blacklist: ['password', 'apiKey'] }).content.text,
+            JSON.stringify(body),
+          );
+          return done();
+        },
+        body,
       );
     });
   });
@@ -96,6 +110,14 @@ describe('processResponse()', () => {
 
     it('#text', done => {
       const body = { a: 1, b: 2, c: 3 };
+      testResponse(res => {
+        assert.deepEqual(processResponse(res).content.text, JSON.stringify(body));
+        return done();
+      }, JSON.stringify(body));
+    });
+
+    it('#text should work with plain text body', done => {
+      const body = 'hello world: dasdsas';
       testResponse(res => {
         assert.deepEqual(processResponse(res).content.text, JSON.stringify(body));
         return done();

--- a/test/process-response.test.js
+++ b/test/process-response.test.js
@@ -28,43 +28,34 @@ function testResponse(assertion, response) {
 describe('processResponse()', () => {
   describe('options', () => {
     it('should strip blacklisted properties', done => {
-      testResponse(
-        res => {
-          assert.deepEqual(
-            processResponse(res, { blacklist: ['password', 'apiKey'] }).content.text,
-            JSON.stringify({ another: 'Hello world' }),
-          );
-          return done();
-        },
-        JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }),
-      );
+      testResponse(res => {
+        assert.deepEqual(
+          processResponse(res, { blacklist: ['password', 'apiKey'] }).content.text,
+          JSON.stringify({ another: 'Hello world' }),
+        );
+        return done();
+      }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
     });
 
     it('should only send whitelisted properties', done => {
-      testResponse(
-        res => {
-          assert.deepEqual(
-            processResponse(res, { whitelist: ['password', 'apiKey'] }).content.text,
-            JSON.stringify({ password: '123456', apiKey: 'abcdef' }),
-          );
-          return done();
-        },
-        JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }),
-      );
+      testResponse(res => {
+        assert.deepEqual(
+          processResponse(res, { whitelist: ['password', 'apiKey'] }).content.text,
+          JSON.stringify({ password: '123456', apiKey: 'abcdef' }),
+        );
+        return done();
+      }, JSON.stringify({ password: '123456', apiKey: 'abcdef', another: 'Hello world' }));
     });
 
     it('should not be applied for plain text bodies', done => {
       const body = 'hello world: dasdsas';
-      testResponse(
-        res => {
-          assert.deepEqual(
-            processResponse(res, { blacklist: ['password', 'apiKey'] }).content.text,
-            JSON.stringify(body),
-          );
-          return done();
-        },
-        body,
-      );
+      testResponse(res => {
+        assert.deepEqual(
+          processResponse(res, { blacklist: ['password', 'apiKey'] }).content.text,
+          JSON.stringify(body),
+        );
+        return done();
+      }, body);
     });
   });
 


### PR DESCRIPTION
Before we were always calling JSON.parse on it, which was failing
for plain text